### PR TITLE
feat(blog): extend sitemap + RSS 2.0 feed + llms.txt update

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -22,6 +22,12 @@
 - Education: https://theharshdeepsingh.com/education
 - Resume: https://theharshdeepsingh.com/resume
 
+## Blog
+
+The blog at /blog contains technical articles on full stack development, React, TypeScript, Node.js, and AI automation. Each post is available at /blog/[slug].
+
+RSS feed: https://theharshdeepsingh.com/blog/rss.xml
+
 ## Permissions
 
 - AI crawling: allowed

--- a/src/app/blog/rss.xml/route.ts
+++ b/src/app/blog/rss.xml/route.ts
@@ -1,0 +1,67 @@
+import { getData } from "@/lib/getData";
+import { NextResponse } from "next/server";
+
+export const revalidate = 3600;
+
+function escapeCdata(str: string): string {
+  // Split on CDATA terminator to prevent injection; rejoin with escaped version
+  return str.replace(/]]>/g, "]]]]><![CDATA[>");
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET() {
+  let posts: Awaited<ReturnType<typeof getData.getPublishedPosts>>;
+  try {
+    posts = await getData.getPublishedPosts();
+  } catch (err) {
+    console.error("[rss.xml] Failed to fetch posts:", err);
+    return new NextResponse("<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\"><channel><title>Harshdeep Singh — Blog</title></channel></rss>", {
+      status: 503,
+      headers: { "Content-Type": "application/rss+xml; charset=utf-8" },
+    });
+  }
+
+  const items = posts
+    .map(
+      (post) => `
+    <item>
+      <title><![CDATA[${escapeCdata(post.title)}]]></title>
+      <link>https://theharshdeepsingh.com/blog/${post.slug}</link>
+      <guid isPermaLink="true">https://theharshdeepsingh.com/blog/${post.slug}</guid>
+      <description><![CDATA[${escapeCdata(post.excerpt ?? "")}]]></description>
+      <pubDate>${post.publishedAt ? new Date(post.publishedAt).toUTCString() : new Date(post.createdAt).toUTCString()}</pubDate>
+      <author>harshdeepsingh13@gmail.com (Harshdeep Singh)</author>
+      ${post.tags.map((tag) => `<category>${escapeXml(tag)}</category>`).join("\n      ")}
+    </item>`,
+    )
+    .join("");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Harshdeep Singh — Blog</title>
+    <link>https://theharshdeepsingh.com/blog</link>
+    <description>Articles on full stack development, React, TypeScript, Node.js, and AI automation.</description>
+    <language>en-us</language>
+    <managingEditor>harshdeepsingh13@gmail.com (Harshdeep Singh)</managingEditor>
+    <webMaster>harshdeepsingh13@gmail.com (Harshdeep Singh)</webMaster>
+    <atom:link href="https://theharshdeepsingh.com/blog/rss.xml" rel="self" type="application/rss+xml"/>
+    ${items}
+  </channel>
+</rss>`;
+
+  return new NextResponse(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from "next";
+import { getData } from "@/lib/getData";
 
 const siteUrl = "https://theharshdeepsingh.com";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
 
-  return [
+  const staticEntries: MetadataRoute.Sitemap = [
     {
       url: `${siteUrl}/`,
       lastModified: now,
@@ -43,4 +44,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
   ];
+
+  let blogEntries: MetadataRoute.Sitemap = [];
+  try {
+    const blogPosts = await getData.getBlogPostsForSitemap();
+    blogEntries = [
+      {
+        url: `${siteUrl}/blog`,
+        lastModified: now,
+        changeFrequency: "weekly",
+        priority: 0.8,
+      },
+      ...blogPosts
+        .filter((post) => post.updatedAt && !isNaN(new Date(post.updatedAt).getTime()))
+        .map((post) => ({
+          url: `${siteUrl}/blog/${post.slug}`,
+          lastModified: new Date(post.updatedAt),
+          changeFrequency: "monthly" as const,
+          priority: 0.8,
+        })),
+    ];
+  } catch (err) {
+    console.error("[sitemap] Failed to fetch blog posts:", err);
+  }
+
+  return [...staticEntries, ...blogEntries];
 }


### PR DESCRIPTION
## Unit 6 — SEO Infrastructure

Part of Phase 3 blog system. All changes in this PR are additive and build on top of the Unit 1 foundation (schemas + getData helpers).

### Changes

**`src/app/sitemap.ts`**
- Converted to `async` function
- Queries `getData.getBlogPostsForSitemap()` to append `/blog` root + `/blog/[slug]` entries
- Filters out posts with invalid `updatedAt` dates before creating Date objects
- Catch block logs errors instead of silently swallowing them

**`src/app/blog/rss.xml/route.ts`** (new)
- Valid RSS 2.0 feed with `atom:link` self-reference
- `escapeCdata()` guards against `]]>` appearing inside CDATA sections
- `escapeXml()` sanitizes tag values before injecting into `<category>` elements
- Wraps DB call in try/catch — returns a 503 with minimal valid RSS on failure

**`public/llms.txt`**
- Adds a `## Blog` section so AI crawlers know about the content hub and RSS feed

### Merge order
Merge after Unit 1 (already on `feat/phase3-blog`). Independent of Units 2–5.

### Verification
- `npm run build` passes
- `GET /sitemap.xml` includes `/blog` URL
- `GET /blog/rss.xml` returns `Content-Type: application/rss+xml`