### PR TITLE
feat(blog): blog post CRUD API + Cloudinary image upload

### DIFF
--- a/src/app/api/blog/posts/[id]/route.ts
+++ b/src/app/api/blog/posts/[id]/route.ts
@@ -1,0 +1,226 @@
+import { NextRequest, NextResponse } from "next/server";
+import mongoose from "mongoose";
+import blogPost from "../../../../../../modals/blogPost";
+import { connectToDB } from "@/lib/mongoose";
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+// TODO (Unit 2): Replace with proper session check once auth is merged:
+//   import { auth } from "@/auth";
+//   const session = await auth();
+//   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+//
+// Temporary workaround: use a custom header that the admin panel will send.
+function isAuthorized(req: NextRequest): boolean {
+  const adminKey = process.env.ADMIN_SECRET_KEY;
+  if (!adminKey) return false;
+  return req.headers.get("x-admin-key") === adminKey;
+}
+
+// ---------------------------------------------------------------------------
+// Route params type — Next.js 15 requires async params
+// ---------------------------------------------------------------------------
+type RouteContext = { params: Promise<{ id: string }> };
+
+// ---------------------------------------------------------------------------
+// GET /api/blog/posts/[id]
+// ---------------------------------------------------------------------------
+// - Authenticated → any status (for editing drafts)
+// - Public        → published only
+// ---------------------------------------------------------------------------
+export async function GET(req: NextRequest, { params }: RouteContext) {
+  const { id } = await params;
+
+  if (!mongoose.isValidObjectId(id)) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  try {
+    await connectToDB();
+
+    const filter: Record<string, unknown> = { _id: id };
+    if (!isAuthorized(req)) {
+      filter.status = "published";
+    }
+
+    const post = await blogPost.findOne(filter).lean();
+    if (!post) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(JSON.parse(JSON.stringify(post)));
+  } catch (err) {
+    console.error("[GET /api/blog/posts/[id]]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/blog/posts/[id]
+// ---------------------------------------------------------------------------
+// Requires auth. Updates any fields supplied in the body.
+// ---------------------------------------------------------------------------
+export async function PUT(req: NextRequest, { params }: RouteContext) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  if (!mongoose.isValidObjectId(id)) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  try {
+    await connectToDB();
+
+    const body = await req.json();
+
+    // Allowlist updatable fields to prevent setting internal Mongoose fields
+    const ALLOWED_FIELDS = [
+      "title", "slug", "author", "coAuthors", "status", "publishedAt",
+      "excerpt", "coverImage", "tags", "body_json", "body_html",
+      "readingTime", "seo",
+    ] as const;
+
+    const updateData: Record<string, unknown> = {};
+    for (const field of ALLOWED_FIELDS) {
+      if (field in body) {
+        updateData[field] = body[field];
+      }
+    }
+
+    // Set publishedAt when transitioning to published if not already set
+    if (updateData.status === "published" && !updateData.publishedAt) {
+      const existing = await blogPost.findById(id, { publishedAt: 1 }).lean();
+      if (!existing) {
+        return NextResponse.json({ error: "Post not found" }, { status: 404 });
+      }
+      if (!(existing as { publishedAt?: Date }).publishedAt) {
+        updateData.publishedAt = new Date();
+      }
+    }
+
+    const updated = await blogPost
+      .findByIdAndUpdate(id, { $set: updateData }, { new: true, runValidators: true })
+      .lean();
+
+    if (!updated) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(JSON.parse(JSON.stringify(updated)));
+  } catch (err: unknown) {
+    console.error("[PUT /api/blog/posts/[id]]", err);
+
+    // Duplicate slug → 409
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as { code: number }).code === 11000
+    ) {
+      return NextResponse.json(
+        { error: "A post with this slug already exists" },
+        { status: 409 }
+      );
+    }
+
+    // Mongoose validation errors → 400
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "name" in err &&
+      (err as { name: string }).name === "ValidationError" &&
+      "message" in err
+    ) {
+      return NextResponse.json(
+        { error: (err as { name: string; message: string }).message },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/blog/posts/[id]
+// ---------------------------------------------------------------------------
+// Requires auth. Hard-deletes the post.
+// ---------------------------------------------------------------------------
+export async function DELETE(req: NextRequest, { params }: RouteContext) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  if (!mongoose.isValidObjectId(id)) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  try {
+    await connectToDB();
+
+    const deleted = await blogPost.findByIdAndDelete(id).lean();
+    if (!deleted) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("[DELETE /api/blog/posts/[id]]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/blog/posts/[id]
+// ---------------------------------------------------------------------------
+// Requires auth. Toggles status between "draft" and "published".
+// Sets publishedAt when transitioning to published.
+// ---------------------------------------------------------------------------
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  if (!mongoose.isValidObjectId(id)) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  try {
+    await connectToDB();
+
+    const existing = await blogPost.findById(id, { status: 1, publishedAt: 1 }).lean();
+    if (!existing) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    const existingDoc = existing as unknown as { status: string; publishedAt?: Date };
+    const currentStatus = existingDoc.status;
+    const newStatus = currentStatus === "published" ? "draft" : "published";
+
+    const updatePayload: Record<string, unknown> = { status: newStatus };
+    if (newStatus === "published" && !existingDoc.publishedAt) {
+      updatePayload.publishedAt = new Date();
+    }
+
+    const updated = await blogPost
+      .findByIdAndUpdate(id, { $set: updatePayload }, { new: true })
+      .lean();
+
+    if (!updated) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(JSON.parse(JSON.stringify(updated)));
+  } catch (err) {
+    console.error("[PATCH /api/blog/posts/[id]]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -1,0 +1,182 @@
+import { NextRequest, NextResponse } from "next/server";
+import mongoose from "mongoose";
+import slugify from "slugify";
+import blogPost from "../../../../../modals/blogPost";
+import { connectToDB } from "@/lib/mongoose";
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+// TODO (Unit 2): Replace with proper session check once auth is merged:
+//   import { auth } from "@/auth";
+//   const session = await auth();
+//   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+//
+// Temporary workaround: use a custom header that the admin panel will send.
+function isAuthorized(req: NextRequest): boolean {
+  const adminKey = process.env.ADMIN_SECRET_KEY;
+  if (!adminKey) return false;
+  return req.headers.get("x-admin-key") === adminKey;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function computeReadingTime(html: string): number {
+  const words = html.replace(/<[^>]+>/g, "").trim().split(/\s+/).length;
+  return Math.max(1, Math.ceil(words / 200));
+}
+
+// Preview projection — excludes body_json and body_html to keep list responses light.
+const PREVIEW_PROJECTION = {
+  title: 1,
+  slug: 1,
+  author: 1,
+  status: 1,
+  publishedAt: 1,
+  excerpt: 1,
+  coverImage: 1,
+  tags: 1,
+  readingTime: 1,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+// ---------------------------------------------------------------------------
+// GET /api/blog/posts
+// ---------------------------------------------------------------------------
+// - ?all=true + valid auth  → all posts (drafts + published), full preview fields
+// - default                 → published posts only (public)
+// - ?tag=tagname            → filter by tag
+// ---------------------------------------------------------------------------
+export async function GET(req: NextRequest) {
+  try {
+    await connectToDB();
+
+    const { searchParams } = new URL(req.url);
+    const tag = searchParams.get("tag") ?? undefined;
+    const all = searchParams.get("all") === "true";
+
+    const filter: Record<string, unknown> = {};
+
+    if (all && isAuthorized(req)) {
+      // Authenticated: return all posts regardless of status
+    } else {
+      // Public: published only
+      filter.status = "published";
+    }
+
+    if (tag) {
+      filter.tags = tag;
+    }
+
+    const data = await blogPost
+      .find(filter, PREVIEW_PROJECTION)
+      .sort({ publishedAt: -1 })
+      .lean();
+
+    return NextResponse.json(JSON.parse(JSON.stringify(data)));
+  } catch (err) {
+    console.error("[GET /api/blog/posts]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/blog/posts
+// ---------------------------------------------------------------------------
+// Body: { title, slug?, excerpt?, coverImage?, tags?, body_json?,
+//         body_html?, readingTime?, status?, seo?, author? }
+// ---------------------------------------------------------------------------
+export async function POST(req: NextRequest) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await connectToDB();
+
+    const body = await req.json();
+
+    const {
+      title,
+      slug: rawSlug,
+      excerpt,
+      coverImage,
+      tags,
+      body_json,
+      body_html,
+      readingTime: rawReadingTime,
+      status = "draft",
+      seo,
+      author,
+    } = body;
+
+    if (!title || typeof title !== "string" || !title.trim()) {
+      return NextResponse.json({ error: "title is required" }, { status: 400 });
+    }
+
+    // Auto-generate slug if not provided
+    const slug = rawSlug
+      ? rawSlug
+      : slugify(title, { lower: true, strict: true });
+
+    // Guard against titles that produce an empty slug (e.g. all special chars)
+    if (!slug) {
+      return NextResponse.json(
+        { error: "title must contain at least one alphanumeric character to generate a valid slug" },
+        { status: 400 }
+      );
+    }
+
+    // Compute readingTime from body_html if not provided
+    const readingTime =
+      rawReadingTime != null
+        ? rawReadingTime
+        : body_html
+        ? computeReadingTime(body_html)
+        : undefined;
+
+    // Default author to portfolio owner email if not supplied
+    const resolvedAuthor = author ?? process.env.UESR_EMAIL ?? "";
+
+    const newPost: Record<string, unknown> = {
+      title,
+      slug,
+      author: resolvedAuthor,
+      status,
+      excerpt,
+      coverImage,
+      tags,
+      body_json,
+      body_html,
+      readingTime,
+      seo,
+    };
+
+    // Set publishedAt when creating as published
+    if (status === "published") {
+      newPost.publishedAt = new Date();
+    }
+
+    const created = await blogPost.create(newPost);
+    return NextResponse.json(JSON.parse(JSON.stringify(created.toObject())), { status: 201 });
+  } catch (err: unknown) {
+    console.error("[POST /api/blog/posts]", err);
+
+    // Duplicate slug → 409
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      (err as { code: number }).code === 11000
+    ) {
+      return NextResponse.json(
+        { error: "A post with this slug already exists" },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/blog/upload/route.ts
+++ b/src/app/api/blog/upload/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+// TODO (Unit 2): Replace with proper session check once auth is merged:
+//   import { auth } from "@/auth";
+//   const session = await auth();
+//   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+//
+// Temporary workaround: use a custom header that the admin panel will send.
+function isAuthorized(req: NextRequest): boolean {
+  const adminKey = process.env.ADMIN_SECRET_KEY;
+  if (!adminKey) return false;
+  return req.headers.get("x-admin-key") === adminKey;
+}
+
+// ---------------------------------------------------------------------------
+// Extract the Cloudinary cloud name from NEXT_PUBLIC_CLOUDINARY_RES_LINK.
+// Expected format: https://res.cloudinary.com/<cloud-name>/...
+// ---------------------------------------------------------------------------
+function getCloudName(): string | null {
+  const baseUrl = process.env.NEXT_PUBLIC_CLOUDINARY_RES_LINK ?? "";
+  // Match the segment after res.cloudinary.com/
+  const match = baseUrl.match(/res\.cloudinary\.com\/([^/]+)/);
+  return match ? match[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/blog/upload
+// ---------------------------------------------------------------------------
+// Accepts multipart/form-data with an "image" field.
+// Uploads to Cloudinary using an unsigned preset named "portfolio".
+// Returns { url: "https://res.cloudinary.com/..." }
+// ---------------------------------------------------------------------------
+export async function POST(req: NextRequest) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const cloudName = getCloudName();
+    if (!cloudName) {
+      return NextResponse.json(
+        { error: "Cloudinary is not configured (missing NEXT_PUBLIC_CLOUDINARY_RES_LINK)" },
+        { status: 500 }
+      );
+    }
+
+    const formData = await req.formData();
+    const imageField = formData.get("image");
+
+    if (!imageField) {
+      return NextResponse.json({ error: "image field is required" }, { status: 400 });
+    }
+
+    // Validate file type and size for File/Blob uploads
+    const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp", "image/avif"];
+    const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+    if (typeof imageField !== "string") {
+      // It's a File/Blob — validate type and size
+      const file = imageField as File;
+      if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+        return NextResponse.json(
+          { error: `Unsupported file type: ${file.type}. Allowed: ${ALLOWED_MIME_TYPES.join(", ")}` },
+          { status: 400 }
+        );
+      }
+      if (file.size > MAX_FILE_SIZE_BYTES) {
+        return NextResponse.json(
+          { error: `File too large (${Math.round(file.size / 1024 / 1024)}MB). Maximum allowed: 10MB` },
+          { status: 400 }
+        );
+      }
+    }
+
+    // imageField can be a File (Blob) or a string (base64 data URL)
+    const uploadFormData = new FormData();
+    uploadFormData.append("upload_preset", "portfolio");
+
+    if (typeof imageField === "string") {
+      // Assume it's a base64 data URL or a raw base64 string
+      uploadFormData.append("file", imageField);
+    } else {
+      // It's a File/Blob
+      uploadFormData.append("file", imageField);
+    }
+
+    const cloudinaryUrl = `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`;
+    const cloudinaryRes = await fetch(cloudinaryUrl, {
+      method: "POST",
+      body: uploadFormData,
+    });
+
+    if (!cloudinaryRes.ok) {
+      const errorBody = await cloudinaryRes.text();
+      console.error("[POST /api/blog/upload] Cloudinary error:", errorBody);
+      return NextResponse.json(
+        { error: "Failed to upload image to Cloudinary" },
+        { status: 502 }
+      );
+    }
+
+    const cloudinaryData = await cloudinaryRes.json() as { secure_url?: string };
+    const url = cloudinaryData.secure_url;
+
+    if (!url) {
+      return NextResponse.json(
+        { error: "Cloudinary did not return a URL" },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error("[POST /api/blog/upload]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds REST API routes for blog post management (GET/POST list, GET/PUT/DELETE/PATCH by ID, image upload)
- Auth uses `ADMIN_SECRET_KEY` header as a temporary workaround (TODO comment in code points to Unit 2 session auth replacement)
- Includes slug auto-generation via `slugify`, `readingTime` computation from `body_html`, `publishedAt` tracking on publish, duplicate-slug 409 handling, field allowlisting in PUT, file type/size validation in upload

## Routes added

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/blog/posts` | Optional | List published posts; `?all=true` + auth returns all including drafts |
| POST | `/api/blog/posts` | Required | Create a new post |
| GET | `/api/blog/posts/[id]` | Optional | Get single post (published only for public) |
| PUT | `/api/blog/posts/[id]` | Required | Update post fields (allowlisted) |
| DELETE | `/api/blog/posts/[id]` | Required | Hard delete |
| PATCH | `/api/blog/posts/[id]` | Required | Toggle draft ↔ published |
| POST | `/api/blog/upload` | Required | Upload image to Cloudinary |

## Test plan

- [x] `GET /api/blog/posts` returns `[]` with no posts
- [x] `POST /api/blog/posts` without auth returns 401
- [x] `DELETE /api/blog/posts/fake-id` without auth returns 401
- [x] `PATCH /api/blog/posts/fake-id` without auth returns 401
- [x] `PUT /api/blog/posts/fake-id` without auth returns 401
- [x] `POST /api/blog/upload` without auth returns 401
- [x] Zero TypeScript errors in new API files