### PR TITLE
feat(blog): public blog listing and post pages with ISR

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,7 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  serverExternalPackages: ["isomorphic-dompurify", "jsdom"],
   poweredByHeader: false,
   reactStrictMode: true,
   async redirects() {

--- a/src/app/blog/[slug]/loading.tsx
+++ b/src/app/blog/[slug]/loading.tsx
@@ -1,0 +1,48 @@
+import Skeleton from "@mui/material/Skeleton";
+import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
+
+const BlogPostLoading = () => {
+  return (
+    <Box sx={{ maxWidth: "1200px", margin: "0 auto", padding: "3rem 15px" }}>
+      {/* Cover image skeleton */}
+      <Skeleton variant="rectangular" width="100%" height={360} sx={{ borderRadius: "16px", mb: 3 }} />
+
+      {/* Title skeleton */}
+      <Skeleton variant="text" width="75%" height={52} sx={{ mb: 1 }} />
+      <Skeleton variant="text" width="45%" height={36} sx={{ mb: 2 }} />
+
+      {/* Meta row */}
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        {[120, 90, 100, 160].map((w, i) => (
+          <Grid key={i}>
+            <Skeleton variant="text" width={w} height={22} />
+          </Grid>
+        ))}
+      </Grid>
+
+      {/* Body paragraphs */}
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Skeleton
+          key={i}
+          variant="text"
+          width={i % 5 === 4 ? "60%" : "100%"}
+          height={22}
+          sx={{ mb: 0.5 }}
+        />
+      ))}
+      <Skeleton variant="text" width="100%" height={22} sx={{ mb: 2, mt: 1 }} />
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton
+          key={`b2-${i}`}
+          variant="text"
+          width={i % 4 === 3 ? "40%" : "100%"}
+          height={22}
+          sx={{ mb: 0.5 }}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default BlogPostLoading;

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,100 @@
+import Breadcrumbs from "@/components/Breadcrumbs";
+import BlogPostContent from "@/components/BlogPostContent";
+import { getData } from "@/lib/getData";
+import { sanitizeHtml } from "@/lib/sanitize";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+export const revalidate = 3600;
+
+const SITE_URL = "https://theharshdeepsingh.com";
+
+export async function generateStaticParams() {
+  const posts = await getData.getBlogPostsForSitemap();
+  return posts.map((p) => ({ slug: p.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getData.getBlogPostBySlug(slug);
+  if (!post) return {};
+
+  const ogImage = post.seo?.ogImage ?? post.coverImage;
+
+  return {
+    title: post.seo?.metaTitle ?? post.title,
+    description: post.seo?.metaDescription ?? post.excerpt,
+    alternates: { canonical: `${SITE_URL}/blog/${post.slug}` },
+    openGraph: {
+      title: post.seo?.metaTitle ?? post.title,
+      description: post.seo?.metaDescription ?? post.excerpt,
+      images: ogImage ? [{ url: ogImage }] : undefined,
+      type: "article",
+      publishedTime: post.publishedAt,
+      modifiedTime: post.updatedAt,
+      url: `${SITE_URL}/blog/${post.slug}`,
+      siteName: "Harshdeep Singh",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.seo?.metaTitle ?? post.title,
+      description: post.seo?.metaDescription ?? post.excerpt,
+      images: ogImage ? [ogImage] : undefined,
+    },
+  };
+}
+
+const BlogPostPage = async ({ params }: { params: Promise<{ slug: string }> }) => {
+  const { slug } = await params;
+  const [post, relatedPosts] = await Promise.all([
+    getData.getBlogPostBySlug(slug),
+    getData.getRelatedPosts(slug, 3),
+  ]);
+
+  if (!post) notFound();
+
+  const safeHtml = post.body_html ? await sanitizeHtml(post.body_html) : "";
+
+  const ogImage = post.seo?.ogImage ?? post.coverImage;
+
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.excerpt,
+    image: ogImage,
+    author: { "@id": `${SITE_URL}/#person` },
+    publisher: { "@id": `${SITE_URL}/#person` },
+    datePublished: post.publishedAt,
+    dateModified: post.updatedAt,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `${SITE_URL}/blog/${post.slug}`,
+    },
+    keywords: post.tags,
+    inLanguage: "en-US",
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
+      <Breadcrumbs
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Blog", href: "/blog" },
+          { label: post.title, href: `/blog/${post.slug}` },
+        ]}
+      />
+      <BlogPostContent post={post} relatedPosts={relatedPosts} safeHtml={safeHtml} />
+    </>
+  );
+};
+
+export default BlogPostPage;

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,58 @@
+import Breadcrumbs from "@/components/Breadcrumbs";
+import BlogListingPage from "@/components/BlogListingPage";
+import { getData } from "@/lib/getData";
+import type { Metadata } from "next";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Blog — Harshdeep Singh",
+  description:
+    "Articles on full stack development, React, TypeScript, Node.js, and AI automation by Harshdeep Singh.",
+  alternates: { canonical: "https://theharshdeepsingh.com/blog" },
+  openGraph: {
+    title: "Blog — Harshdeep Singh",
+    description:
+      "Articles on full stack development, React, TypeScript, Node.js, and AI automation by Harshdeep Singh.",
+    url: "https://theharshdeepsingh.com/blog",
+    siteName: "Harshdeep Singh",
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Blog — Harshdeep Singh",
+    description:
+      "Articles on full stack development, React, TypeScript, Node.js, and AI automation by Harshdeep Singh.",
+  },
+};
+
+const BlogPage = async ({
+  searchParams,
+}: {
+  searchParams: Promise<{ tag?: string }>;
+}) => {
+  const params = await searchParams;
+  const activeTag = params.tag ?? "all";
+
+  const [allPosts, filteredPosts] = await Promise.all([
+    getData.getPublishedPosts(),
+    activeTag !== "all" ? getData.getPublishedPosts(activeTag) : Promise.resolve([]),
+  ]);
+
+  const posts = activeTag !== "all" ? filteredPosts : allPosts;
+
+  return (
+    <>
+      <Breadcrumbs
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Blog", href: "/blog" },
+        ]}
+      />
+      <BlogListingPage posts={posts} allPosts={allPosts} activeTag={activeTag} />
+    </>
+  );
+};
+
+export default BlogPage;

--- a/src/components/BlogCard/index.tsx
+++ b/src/components/BlogCard/index.tsx
@@ -1,0 +1,73 @@
+import type { BlogPostPreview } from "@/types/blog";
+import { faClock, faUser } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Link from "next/link";
+import {
+  BlogCardContent,
+  BlogCardExcerpt,
+  BlogCardImage,
+  BlogCardMeta,
+  BlogCardMetaDot,
+  BlogCardTag,
+  BlogCardTagsRow,
+  BlogCardTitle,
+  BlogCardWrapper,
+} from "./styles";
+
+function formatDate(dateStr?: string): string {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+const BlogCard = ({ post, delay }: { post: BlogPostPreview; delay?: number }) => {
+  return (
+    <Link href={`/blog/${post.slug}`} style={{ display: "block", height: "100%", textDecoration: "none", color: "inherit" }}>
+      <BlogCardWrapper delay={delay}>
+        {post.coverImage && (
+          <BlogCardImage>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={post.coverImage} alt={post.title} loading="lazy" />
+          </BlogCardImage>
+        )}
+        <BlogCardContent>
+          <BlogCardTitle>{post.title}</BlogCardTitle>
+          {post.excerpt && <BlogCardExcerpt>{post.excerpt}</BlogCardExcerpt>}
+          {post.tags.length > 0 && (
+            <BlogCardTagsRow>
+              {post.tags.slice(0, 4).map((tag) => (
+                <BlogCardTag key={tag}>{tag}</BlogCardTag>
+              ))}
+            </BlogCardTagsRow>
+          )}
+          <BlogCardMeta>
+            {post.author && (
+              <>
+                <span>
+                  <FontAwesomeIcon icon={faUser} style={{ marginRight: "4px", fontSize: "0.7rem" }} />
+                  {post.author}
+                </span>
+                <BlogCardMetaDot aria-hidden="true">·</BlogCardMetaDot>
+              </>
+            )}
+            {post.readingTime != null && (
+              <>
+                <span>
+                  <FontAwesomeIcon icon={faClock} style={{ marginRight: "4px", fontSize: "0.7rem" }} />
+                  {post.readingTime} min read
+                </span>
+                <BlogCardMetaDot aria-hidden="true">·</BlogCardMetaDot>
+              </>
+            )}
+            <span>{formatDate(post.publishedAt ?? post.createdAt)}</span>
+          </BlogCardMeta>
+        </BlogCardContent>
+      </BlogCardWrapper>
+    </Link>
+  );
+};
+
+export default BlogCard;

--- a/src/components/BlogCard/styles.tsx
+++ b/src/components/BlogCard/styles.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { fadeIn } from "@/theme/animations";
+import { styled } from "@mui/material/styles";
+
+export const BlogCardWrapper = styled("article", {
+  shouldForwardProp: (prop) => prop !== "delay",
+})<{ delay?: number }>(({ theme, delay = 0 }) => ({
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+  background: theme.palette.primary.glow,
+  border: `1px solid ${theme.palette.primary.border}`,
+  borderRadius: "16px",
+  overflow: "hidden",
+  textDecoration: "none",
+  color: "inherit",
+  cursor: "pointer",
+  animation: `${fadeIn} 0.5s ease both`,
+  animationDelay: `${delay}s`,
+  transition: "transform 300ms ease, border-color 300ms, box-shadow 300ms",
+
+  "&:hover": {
+    transform: "translateY(-4px)",
+    borderColor: theme.palette.primary.alpha20,
+    boxShadow: `0 8px 32px ${theme.palette.primary.alpha10}, 0 4px 16px ${theme.palette.custom.main60}`,
+  },
+}));
+
+export const BlogCardImage = styled("div")({
+  width: "100%",
+  aspectRatio: "16/9",
+  overflow: "hidden",
+  flexShrink: 0,
+
+  "& img": {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    display: "block",
+  },
+});
+
+export const BlogCardContent = styled("div")({
+  display: "flex",
+  flexDirection: "column",
+  flex: 1,
+  padding: "1.25rem",
+  gap: "0.75rem",
+});
+
+export const BlogCardTitle = styled("h2")(({ theme }) => ({
+  margin: 0,
+  fontSize: "1.05rem",
+  fontWeight: 700,
+  fontFamily: "'Outfit', sans-serif",
+  color: theme.palette.text.primary,
+  lineHeight: 1.4,
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  overflow: "hidden",
+}));
+
+export const BlogCardExcerpt = styled("p")(({ theme }) => ({
+  margin: 0,
+  fontSize: "0.875rem",
+  color: theme.palette.custom.tertiaryText,
+  fontWeight: 300,
+  lineHeight: 1.7,
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  overflow: "hidden",
+  flex: 1,
+}));
+
+export const BlogCardTagsRow = styled("div")({
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.4rem",
+});
+
+export const BlogCardTag = styled("span")(({ theme }) => ({
+  fontSize: "0.75rem",
+  padding: "2px 8px",
+  borderRadius: "50px",
+  border: `1px solid ${theme.palette.primary.border}`,
+  color: theme.palette.primary.main,
+  backgroundColor: theme.palette.primary.glow,
+}));
+
+export const BlogCardMeta = styled("div")(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "0.75rem",
+  fontSize: "0.78rem",
+  color: theme.palette.custom.accentText,
+  borderTop: `1px solid ${theme.palette.divider}`,
+  paddingTop: "0.75rem",
+  flexWrap: "wrap",
+}));
+
+export const BlogCardMetaDot = styled("span")(({ theme }) => ({
+  color: theme.palette.divider,
+}));

--- a/src/components/BlogListingPage/index.tsx
+++ b/src/components/BlogListingPage/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Container, PageHeader, PageLead, Row } from "@/app/_globalStyles";
+import BlogCard from "@/components/BlogCard";
+import BlogTagFilter from "@/components/BlogTagFilter";
+import type { BlogPostPreview } from "@/types/blog";
+import Grid from "@mui/material/Grid";
+
+interface BlogListingPageProps {
+  posts: BlogPostPreview[];
+  allPosts: BlogPostPreview[];
+  activeTag: string;
+}
+
+const BlogListingPage = ({ posts, allPosts, activeTag }: BlogListingPageProps) => {
+  const uniqueTags = Array.from(
+    new Set(allPosts.flatMap((post) => post.tags))
+  ).sort();
+
+  return (
+    <Container>
+      <PageHeader>Blog</PageHeader>
+      <PageLead>
+        Thoughts on full stack development, React, TypeScript, Node.js, AI automation, and building for the web.
+      </PageLead>
+
+      {uniqueTags.length > 0 && (
+        <BlogTagFilter tags={uniqueTags} activeTag={activeTag} />
+      )}
+
+      {posts.length === 0 ? (
+        <p
+          style={{ textAlign: "center", marginTop: "3rem", opacity: 0.6 }}
+          aria-live="polite"
+        >
+          No posts yet. Check back soon.
+        </p>
+      ) : (
+        <Row spacing={3} sx={{ marginTop: "1.5rem", alignItems: "stretch" }}>
+          {posts.map((post, index) => (
+            <Grid key={post._id} size={{ xs: 12, sm: 6, md: 4 }} sx={{ display: "flex" }}>
+              <BlogCard post={post} delay={0.1 + index * 0.07} />
+            </Grid>
+          ))}
+        </Row>
+      )}
+    </Container>
+  );
+};
+
+export default BlogListingPage;

--- a/src/components/BlogPostContent/index.tsx
+++ b/src/components/BlogPostContent/index.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { Container, PageHeader, Row } from "@/app/_globalStyles";
+import BlogCard from "@/components/BlogCard";
+import type { BlogPost, BlogPostPreview } from "@/types/blog";
+import { faClock, faTag, faUser } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Grid from "@mui/material/Grid";
+import { useTheme } from "@mui/material/styles";
+
+function formatDate(dateStr?: string): string {
+  if (!dateStr) return "";
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+interface BlogPostContentProps {
+  post: BlogPost;
+  relatedPosts: BlogPostPreview[];
+  safeHtml: string;
+}
+
+const BlogPostContent = ({ post, relatedPosts, safeHtml }: BlogPostContentProps) => {
+  const theme = useTheme();
+  return (
+    <Container>
+      {post.coverImage && (
+        <div
+          style={{
+            width: "100%",
+            maxHeight: "420px",
+            overflow: "hidden",
+            borderRadius: "16px",
+            marginBottom: "2rem",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={post.coverImage}
+            alt={post.title}
+            style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+          />
+        </div>
+      )}
+
+      <PageHeader component="h1" sx={{ textAlign: "left", fontSize: { xs: "2rem", md: "2.75rem" } }}>
+        {post.title}
+      </PageHeader>
+
+      {/* Post meta row */}
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "1rem",
+          margin: "1.25rem 0 2rem",
+          fontSize: "0.875rem",
+          opacity: 0.75,
+        }}
+      >
+        {post.author && (
+          <span>
+            <FontAwesomeIcon icon={faUser} style={{ marginRight: "6px" }} />
+            {post.author}
+          </span>
+        )}
+        {post.readingTime != null && (
+          <span>
+            <FontAwesomeIcon icon={faClock} style={{ marginRight: "6px" }} />
+            {post.readingTime} min read
+          </span>
+        )}
+        {post.publishedAt && (
+          <span>{formatDate(post.publishedAt)}</span>
+        )}
+        {post.tags.length > 0 && (
+          <span style={{ display: "flex", alignItems: "center", gap: "0.4rem", flexWrap: "wrap" }}>
+            <FontAwesomeIcon icon={faTag} style={{ fontSize: "0.8rem" }} />
+            {post.tags.join(", ")}
+          </span>
+        )}
+      </div>
+
+      {/* Post body */}
+      {safeHtml && (
+        <div
+          className="blog-post-body"
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+          style={{ lineHeight: 1.85, fontSize: "1.05rem" }}
+        />
+      )}
+
+      {/* Related posts */}
+      {relatedPosts.length > 0 && (
+        <section style={{ marginTop: "4rem", borderTop: `1px solid ${theme.palette.divider}`, paddingTop: "2rem" }}>
+          <h2
+            style={{
+              fontFamily: "'Outfit', sans-serif",
+              fontWeight: 700,
+              fontSize: "1.5rem",
+              marginBottom: "1.5rem",
+            }}
+          >
+            Related Posts
+          </h2>
+          <Row spacing={3} sx={{ alignItems: "stretch" }}>
+            {relatedPosts.map((related, index) => (
+              <Grid key={related._id} size={{ xs: 12, sm: 6, md: 4 }} sx={{ display: "flex" }}>
+                <BlogCard post={related} delay={0.1 + index * 0.07} />
+              </Grid>
+            ))}
+          </Row>
+        </section>
+      )}
+    </Container>
+  );
+};
+
+export default BlogPostContent;

--- a/src/components/BlogTagFilter/index.tsx
+++ b/src/components/BlogTagFilter/index.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { CustomTab, CustomTabs } from "@/app/_globalStyles";
+import { useRouter } from "next/navigation";
+import { SyntheticEvent } from "react";
+
+const BlogTagFilter = ({ tags, activeTag }: { tags: string[]; activeTag: string }) => {
+  const router = useRouter();
+
+  const handleChange = (_event: SyntheticEvent, value: string) => {
+    if (value === "all") {
+      router.push("/blog");
+    } else {
+      router.push(`/blog?tag=${encodeURIComponent(value)}`);
+    }
+  };
+
+  return (
+    <CustomTabs value={activeTag} onChange={handleChange} aria-label="Filter posts by tag">
+      <CustomTab value="all" label="All" />
+      {tags.map((tag) => (
+        <CustomTab key={tag} value={tag} label={tag} />
+      ))}
+    </CustomTabs>
+  );
+};
+
+export default BlogTagFilter;

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,14 @@
+/**
+ * Server-only HTML sanitizer.
+ * Uses isomorphic-dompurify (JSDOM-backed) on the Node.js runtime.
+ * This module must never be imported on the client.
+ */
+import "server-only";
+
+export async function sanitizeHtml(html: string): Promise<string> {
+  if (!html) return "";
+  // Dynamic import keeps jsdom out of the initial bundle and defers
+  // resolution to the Node.js runtime where JSDOM is available.
+  const DOMPurify = (await import("isomorphic-dompurify")).default;
+  return DOMPurify.sanitize(html);
+}


### PR DESCRIPTION
## Summary

- Add `/blog` listing page (ISR, `revalidate = 3600`) with tag filter using URL search params and `CustomTabs`, empty state, and blog card grid
- Add `/blog/[slug]` post page with ISR, `generateStaticParams`, Article JSON-LD schema, DOMPurify sanitization via server-only utility, related posts section, and skeleton loader
- Add `BlogCard` component with cover image, title, excerpt (2-line clamp), tags as chips, reading time, author, and date
- Add `BlogListingPage` and `BlogPostContent` as `"use client"` wrappers to prevent Emotion `keyframes` from bundling in RSC server chunks
- Add `BlogTagFilter` client component that uses `useRouter` to push tag query params without full page reload
- Add `src/lib/sanitize.ts` server-only async sanitizer using dynamic import of `isomorphic-dompurify` to keep JSDOM out of the Next.js bundle
- Add `serverExternalPackages: ["isomorphic-dompurify", "jsdom"]` to `next.config.ts` to prevent bundling JSDOM in the RSC runtime
- Fix pre-existing MUI v9 type errors in admin pages (`InputProps` → `slotProps.input`, `FormHelperTextProps` → `slotProps.formHelperText`, `tippyOptions` removed from BubbleMenu)
- All colors use `theme.palette.*` — no hardcoded values

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] `/blog` renders `<h1>Blog</h1>` with empty state "No posts yet. Check back soon."
- [x] `/blog` has `og:title`, `og:description`, `og:url`, `twitter:card` meta tags in page source
- [x] `/blog/a-non-existent-slug` returns 404 (not 500)
- [x] Build route table shows `/blog` as `ƒ` (Dynamic) and `/blog/[slug]` as `●` (SSG)