### PR TITLE
feat: reading progress bar on blog post pages

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -14,8 +14,10 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { sendGAEvent } from "@next/third-parties/google";
+import { usePathname } from "next/navigation";
 import { useState } from "react";
 import Logo from "../Logo";
+import { useReadingProgress } from "@/hooks/useReadingProgress";
 import {
   DrawerNavItem,
   HamburgerButton,
@@ -25,6 +27,7 @@ import {
   MobileDrawer,
   NavLinkItem,
   NavLinksContainer,
+  ProgressBarFill,
   ThemeButton,
 } from "./styles";
 
@@ -40,6 +43,9 @@ const NAV_LINKS = [
 const Header = ({ basicInformation }: { basicInformation: any }) => {
   const { theme, setTheme } = useThemeContext();
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const pathname = usePathname();
+  const isBlogPost = /^\/blog\/[^/]+/.test(pathname ?? "");
+  const progress = useReadingProgress(isBlogPost);
 
   const onThemeToggle = () => {
     sendGAEvent("event", "toggle_theme");
@@ -77,6 +83,9 @@ const Header = ({ basicInformation }: { basicInformation: any }) => {
             </ThemeButton>
           </div>
         </HeaderContainer>
+        {isBlogPost && (
+          <ProgressBarFill style={{ width: `${progress}%` }} />
+        )}
       </HeaderWrapper>
 
       <MobileDrawer

--- a/src/components/Header/styles.tsx
+++ b/src/components/Header/styles.tsx
@@ -201,3 +201,15 @@ export const ThemeButton = styled("div")(() => ({
   paddingLeft: "0.5rem",
   paddingRight: "0.5rem",
 }));
+
+export const ProgressBarFill = styled("div")(({ theme }) => ({
+  position: "absolute",
+  bottom: 0,
+  left: 0,
+  height: "3px",
+  backgroundColor: theme.palette.primary.main,
+  boxShadow: `0 0 8px ${theme.palette.primary.alpha20}`,
+  transition: "width 150ms linear",
+  pointerEvents: "none",
+  zIndex: 1,
+}));

--- a/src/hooks/useReadingProgress.ts
+++ b/src/hooks/useReadingProgress.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export function useReadingProgress(enabled = true): number {
+  const [progress, setProgress] = useState(0);
+
+  const update = useCallback(() => {
+    const scrolled = window.scrollY;
+    const total = document.documentElement.scrollHeight - window.innerHeight;
+    setProgress(total > 0 ? Math.min(100, (scrolled / total) * 100) : 0);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    window.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update, { passive: true });
+    update();
+    return () => {
+      window.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, [enabled, update]);
+
+  return progress;
+}


### PR DESCRIPTION
## Summary

- Adds a thin 3px cyan bar at the bottom of the sticky header that fills left-to-right as the reader scrolls through a blog post
- Bar is only visible on `/blog/[slug]` routes — does not appear on other pages
- Uses `theme.palette.primary.main` for color and `theme.palette.primary.alpha20` for the glow (20% opacity — visibly renders unlike the 8% `glow` token)

## Files changed

| File | Change |
|------|--------|
| `src/hooks/useReadingProgress.ts` | New hook — passive scroll/resize listeners, accepts `enabled` flag to skip listeners on non-blog pages |
| `src/components/Header/styles.tsx` | Added `ProgressBarFill` styled component |
| `src/components/Header/index.tsx` | Added `usePathname` check, renders bar inside `HeaderWrapper` |

## Test plan

- [ ] Open any published blog post → cyan 3px bar visible at bottom of sticky header
- [ ] Scroll down → bar grows; scroll back to top → bar shrinks to 0
- [ ] Navigate to `/skills`, `/projects`, `/` → bar is absent
- [ ] Mobile: bar also hidden on non-blog pages; renders correctly on blog post pages