### PR TITLE
feat: TipTap JSON import in blog editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Local planning docs and one-time scripts (never commit)
 seo-plan.md
 scripts/
+
+# Temp upload processing directory
+tmp/
 docs/superpowers/
 
 # dependencies

--- a/src/app/api/blog/import-json/route.ts
+++ b/src/app/api/blog/import-json/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/auth";
+import os from "os";
+import path from "path";
+import fs from "fs/promises";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+function isTiptapDoc(obj: unknown): obj is { type: "doc"; content: unknown[] } {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    (obj as Record<string, unknown>)["type"] === "doc" &&
+    Array.isArray((obj as Record<string, unknown>)["content"])
+  );
+}
+
+const KNOWN_NODE_TYPES = new Set([
+  "doc", "paragraph", "text", "heading", "bulletList", "orderedList",
+  "listItem", "blockquote", "codeBlock", "horizontalRule", "image",
+  "youtube", "table", "tableRow", "tableHeader", "tableCell",
+  "chip", "hardBreak",
+]);
+
+function normalizeNode(
+  node: Record<string, unknown>,
+  warnings: string[],
+): Record<string, unknown> {
+  const type = node.type as string;
+  if (type !== "text" && !KNOWN_NODE_TYPES.has(type)) {
+    warnings.push(`Unknown node type "${type}" replaced with paragraph`);
+    node = { type: "paragraph", content: (node.content as unknown[]) ?? [] };
+  }
+  if (Array.isArray(node.content)) {
+    node = {
+      ...node,
+      content: (node.content as Record<string, unknown>[]).map((child) =>
+        normalizeNode(child, warnings),
+      ),
+    };
+  }
+  return node;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let tmpPath: string | null = null;
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file");
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+    }
+    if (!file.name.toLowerCase().endsWith(".json")) {
+      return NextResponse.json({ error: "File must be a .json file" }, { status: 400 });
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: "File exceeds 5 MB limit" }, { status: 400 });
+    }
+
+    const buf = Buffer.from(await file.arrayBuffer());
+    tmpPath = path.join(os.tmpdir(), `tiptap-import-${Date.now()}.json`);
+    await fs.writeFile(tmpPath, buf);
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(buf.toString("utf-8"));
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid JSON: file could not be parsed" },
+        { status: 422 },
+      );
+    }
+
+    if (!isTiptapDoc(raw)) {
+      return NextResponse.json(
+        { error: 'Not a valid TipTap document. Expected { type: "doc", content: [...] }' },
+        { status: 422 },
+      );
+    }
+
+    const warnings: string[] = [];
+    const normalized = normalizeNode(raw as Record<string, unknown>, warnings);
+
+    return NextResponse.json({ json: normalized, warnings });
+  } finally {
+    if (tmpPath) await fs.unlink(tmpPath).catch(() => {});
+  }
+}

--- a/src/app/api/blog/import-json/route.ts
+++ b/src/app/api/blog/import-json/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/auth";
-import os from "os";
 import path from "path";
 import fs from "fs/promises";
+
+const TMP_DIR = path.join(process.cwd(), "tmp");
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 
@@ -65,7 +66,8 @@ export async function POST(req: NextRequest) {
     }
 
     const buf = Buffer.from(await file.arrayBuffer());
-    tmpPath = path.join(os.tmpdir(), `tiptap-import-${Date.now()}.json`);
+    await fs.mkdir(TMP_DIR, { recursive: true });
+    tmpPath = path.join(TMP_DIR, `tiptap-import-${Date.now()}.json`);
     await fs.writeFile(tmpPath, buf);
 
     let raw: unknown;

--- a/src/components/BlogEditor/index.tsx
+++ b/src/components/BlogEditor/index.tsx
@@ -19,7 +19,7 @@ import javascript from "highlight.js/lib/languages/javascript";
 import typescript from "highlight.js/lib/languages/typescript";
 import css from "highlight.js/lib/languages/css";
 import python from "highlight.js/lib/languages/python";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { CharCountWrapper, EditorWrapper } from "./styles";
 import { ChipExtension } from "./ChipExtension";
 import { importTiptapJson } from "@/services/blog/importJson";
@@ -70,6 +70,8 @@ export default function BlogEditor({
   onChange,
   placeholder = "Write your post here…",
 }: BlogEditorProps) {
+  const [, rerender] = useReducer((x: number) => x + 1, 0);
+
   const editor = useEditor({
     extensions: [
       // StarterKit without the extensions we're replacing
@@ -106,6 +108,9 @@ export default function BlogEditor({
       attributes: {
         spellcheck: "true",
       },
+    },
+    onSelectionUpdate() {
+      rerender();
     },
     onUpdate({ editor }) {
       if (onChange) {

--- a/src/components/BlogEditor/index.tsx
+++ b/src/components/BlogEditor/index.tsx
@@ -19,9 +19,10 @@ import javascript from "highlight.js/lib/languages/javascript";
 import typescript from "highlight.js/lib/languages/typescript";
 import css from "highlight.js/lib/languages/css";
 import python from "highlight.js/lib/languages/python";
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CharCountWrapper, EditorWrapper } from "./styles";
 import { ChipExtension } from "./ChipExtension";
+import { importTiptapJson } from "@/services/blog/importJson";
 
 // Configure lowlight with supported languages
 const lowlight = createLowlight();
@@ -131,6 +132,35 @@ export default function BlogEditor({
       editor.commands.setContent(contentHtml, { emitUpdate: false });
     }
   }, [editor, content, contentHtml]);
+
+  const jsonInputRef = useRef<HTMLInputElement>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const handleJsonImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !editor) return;
+    e.target.value = ""; // reset so same file can be re-selected
+
+    if (!editor.isEmpty) {
+      const ok = window.confirm(
+        "Uploading a JSON will replace all existing content and cannot be undone. Continue?",
+      );
+      if (!ok) return;
+    }
+
+    setImportError(null);
+    try {
+      const { json, warnings } = await importTiptapJson(file);
+      if (editor.isDestroyed) return;
+      // TipTap v3: second arg is an options object, not a boolean
+      editor.commands.setContent(json, { emitUpdate: true });
+      if (warnings.length > 0) {
+        setImportError(`Imported with warnings: ${warnings.join("; ")}`);
+      }
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : "Import failed");
+    }
+  };
 
   if (!editor) return null;
 
@@ -324,6 +354,17 @@ export default function BlogEditor({
         >
           ⊞
         </ToolbarBtn>
+        <div className="toolbar-divider" />
+        <ToolbarBtn onClick={() => jsonInputRef.current?.click()} title="Upload TipTap JSON">
+          ↑ JSON
+        </ToolbarBtn>
+        <input
+          ref={jsonInputRef}
+          type="file"
+          accept=".json"
+          style={{ display: "none" }}
+          onChange={handleJsonImport}
+        />
       </div>
 
       {/* Bubble menu for selected text */}
@@ -367,6 +408,22 @@ export default function BlogEditor({
       <CharCountWrapper>
         {wordCount} words · {charCount} characters
       </CharCountWrapper>
+      {importError && (
+        <div
+          style={{
+            fontSize: "0.75rem",
+            color: importError.startsWith("Imported with warnings") ? "#f59e0b" : "#ef4444",
+            marginTop: "4px",
+            padding: "6px 10px",
+            borderRadius: "4px",
+            backgroundColor: importError.startsWith("Imported with warnings")
+              ? "rgba(245,158,11,0.08)"
+              : "rgba(239,68,68,0.08)",
+          }}
+        >
+          {importError}
+        </div>
+      )}
     </EditorWrapper>
   );
 }

--- a/src/components/BlogEditor/styles.tsx
+++ b/src/components/BlogEditor/styles.tsx
@@ -23,7 +23,7 @@ export const EditorWrapper = styled("div")(({ theme }) => ({
     borderBottom: `1px solid ${theme.palette.divider}`,
     backgroundColor: theme.palette.background.default,
     position: "sticky",
-    top: "3rem",
+    top: "4rem",
     zIndex: 10,
     borderRadius: "8px 8px 0 0",
     boxShadow: `0 2px 6px ${theme.palette.primary.alpha10}`,

--- a/src/components/PostEditorForm/index.tsx
+++ b/src/components/PostEditorForm/index.tsx
@@ -9,8 +9,8 @@ import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { styled, useTheme } from "@mui/material/styles";
-import slugify from "slugify";
 import { useCallback, useEffect, useRef, useState } from "react";
+import slugify from "slugify";
 
 // ── Styled components ─────────────────────────────────────────────────────────
 
@@ -42,7 +42,7 @@ const Sidebar = styled(Box)(({ theme }) => ({
   gap: "16px",
   position: "sticky",
   top: "6rem",
-  maxHeight: "calc(100vh - 56px)",
+  maxHeight: "calc(100vh - 120px)",
   overflowY: "auto",
   [theme.breakpoints.down("md")]: {
     width: "100%",
@@ -130,7 +130,10 @@ function buildPayload(form: PostFormState, extra: Record<string, unknown> = {}) 
     title: form.title.trim(),
     slug: form.slug.trim(),
     excerpt: form.excerpt.trim() || undefined,
-    tags: form.tags.split(",").map((t) => t.trim()).filter(Boolean),
+    tags: form.tags
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean),
     coverImage: form.coverImage.trim() || undefined,
     body_json: form.body_json,
     body_html: form.body_html,
@@ -147,19 +150,21 @@ function buildPayload(form: PostFormState, extra: Record<string, unknown> = {}) 
 
 // ── Status indicator (edit mode only) ─────────────────────────────────────────
 
-function StatusIndicator({
-  postStatus,
-  hasDraft,
-}: {
-  postStatus: "draft" | "published";
-  hasDraft: boolean;
-}) {
+function StatusIndicator({ postStatus, hasDraft }: { postStatus: "draft" | "published"; hasDraft: boolean }) {
   const theme = useTheme();
 
   if (postStatus === "draft") {
     return (
       <Box sx={{ display: "flex", alignItems: "center", gap: "8px" }}>
-        <Box sx={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: theme.palette.custom.accentText, flexShrink: 0 }} />
+        <Box
+          sx={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            backgroundColor: theme.palette.custom.accentText,
+            flexShrink: 0,
+          }}
+        />
         <Typography sx={{ fontSize: "0.8rem", color: theme.palette.custom.accentText }}>Draft</Typography>
       </Box>
     );
@@ -169,9 +174,7 @@ function StatusIndicator({
     return (
       <Box sx={{ display: "flex", alignItems: "center", gap: "8px" }}>
         <Box sx={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: "warning.main", flexShrink: 0 }} />
-        <Typography sx={{ fontSize: "0.8rem", color: "warning.main" }}>
-          Published · Unpublished changes
-        </Typography>
+        <Typography sx={{ fontSize: "0.8rem", color: "warning.main" }}>Published · Unpublished changes</Typography>
       </Box>
     );
   }
@@ -179,9 +182,7 @@ function StatusIndicator({
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: "8px" }}>
       <Box sx={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: "success.main", flexShrink: 0 }} />
-      <Typography sx={{ fontSize: "0.8rem", color: "success.main" }}>
-        Published · Up to date
-      </Typography>
+      <Typography sx={{ fontSize: "0.8rem", color: "success.main" }}>Published · Up to date</Typography>
     </Box>
   );
 }
@@ -292,15 +293,12 @@ export default function PostEditorForm({ postId }: PostEditorFormProps) {
     [set],
   );
 
-  const handleEditorChange = useCallback(
-    ({ json, html }: { json: Record<string, unknown>; html: string }) => {
-      if (isSettledRef.current) {
-        isDirtyRef.current = true;
-      }
-      setForm((prev) => (prev ? { ...prev, body_json: json, body_html: html } : prev));
-    },
-    [],
-  );
+  const handleEditorChange = useCallback(({ json, html }: { json: Record<string, unknown>; html: string }) => {
+    if (isSettledRef.current) {
+      isDirtyRef.current = true;
+    }
+    setForm((prev) => (prev ? { ...prev, body_json: json, body_html: html } : prev));
+  }, []);
 
   // ── Auto-save (every 30 s, always as draft) ───────────────────────────────
   // Calls service functions directly (not via mutation hooks) because mutation
@@ -325,9 +323,7 @@ export default function PostEditorForm({ postId }: PostEditorFormProps) {
 
       isDirtyRef.current = false;
       const now = new Date();
-      setAutoSaveStatus(
-        `Last saved at ${now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
-      );
+      setAutoSaveStatus(`Last saved at ${now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`);
     } catch {
       setAutoSaveStatus("Auto-save failed");
     }
@@ -343,8 +339,14 @@ export default function PostEditorForm({ postId }: PostEditorFormProps) {
   const handleSave = async () => {
     if (!form) return;
     setSaveError(null);
-    if (!form.title.trim()) { setSaveError("Title is required."); return; }
-    if (!form.slug.trim()) { setSaveError("Slug is required."); return; }
+    if (!form.title.trim()) {
+      setSaveError("Title is required.");
+      return;
+    }
+    if (!form.slug.trim()) {
+      setSaveError("Slug is required.");
+      return;
+    }
 
     setSaving(true);
     try {
@@ -358,9 +360,7 @@ export default function PostEditorForm({ postId }: PostEditorFormProps) {
 
       isDirtyRef.current = false;
       const now = new Date();
-      setAutoSaveStatus(
-        `Last saved at ${now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
-      );
+      setAutoSaveStatus(`Last saved at ${now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`);
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : "Failed to save post.");
     } finally {
@@ -373,8 +373,14 @@ export default function PostEditorForm({ postId }: PostEditorFormProps) {
   const handlePublish = async () => {
     if (!form) return;
     setSaveError(null);
-    if (!form.title.trim()) { setSaveError("Title is required."); return; }
-    if (!form.slug.trim()) { setSaveError("Slug is required."); return; }
+    if (!form.title.trim()) {
+      setSaveError("Title is required.");
+      return;
+    }
+    if (!form.slug.trim()) {
+      setSaveError("Slug is required.");
+      return;
+    }
 
     setPublishing(true);
     try {
@@ -548,9 +554,7 @@ export default function PostEditorForm({ postId }: PostEditorFormProps) {
       {/* ── Right: metadata sidebar ──────────────────── */}
       <Sidebar>
         <SidebarCard>
-          <Typography sx={{ fontWeight: 600, fontSize: "0.9rem", color: "text.primary" }}>
-            Publish
-          </Typography>
+          <Typography sx={{ fontWeight: 600, fontSize: "0.9rem", color: "text.primary" }}>Publish</Typography>
 
           {isEditMode && <StatusIndicator postStatus={postStatus} hasDraft={hasDraft} />}
 
@@ -632,9 +636,7 @@ export default function PostEditorForm({ postId }: PostEditorFormProps) {
         </SidebarCard>
 
         <SidebarCard>
-          <Typography sx={{ fontWeight: 600, fontSize: "0.9rem", color: "text.primary" }}>
-            URL
-          </Typography>
+          <Typography sx={{ fontWeight: 600, fontSize: "0.9rem", color: "text.primary" }}>URL</Typography>
           <Box>
             <FieldLabel>Slug</FieldLabel>
             <StyledTextField
@@ -656,9 +658,7 @@ export default function PostEditorForm({ postId }: PostEditorFormProps) {
         </SidebarCard>
 
         <SidebarCard>
-          <Typography sx={{ fontWeight: 600, fontSize: "0.9rem", color: "text.primary" }}>
-            Details
-          </Typography>
+          <Typography sx={{ fontWeight: 600, fontSize: "0.9rem", color: "text.primary" }}>Details</Typography>
           <Box>
             <FieldLabel>Excerpt</FieldLabel>
             <StyledTextField

--- a/src/components/PostEditorForm/index.tsx
+++ b/src/components/PostEditorForm/index.tsx
@@ -44,6 +44,7 @@ const Sidebar = styled(Box)(({ theme }) => ({
   top: "6rem",
   maxHeight: "calc(100vh - 120px)",
   overflowY: "auto",
+  borderRadius: "10px",
   [theme.breakpoints.down("md")]: {
     width: "100%",
     position: "static",

--- a/src/services/blog/importJson.ts
+++ b/src/services/blog/importJson.ts
@@ -1,0 +1,17 @@
+export async function importTiptapJson(
+  file: File,
+): Promise<{ json: Record<string, unknown>; warnings: string[] }> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const res = await fetch("/api/blog/import-json", {
+    method: "POST",
+    body: formData,
+  });
+
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error((data as { error?: string }).error ?? "Failed to import JSON");
+  }
+  return data as { json: Record<string, unknown>; warnings: string[] };
+}


### PR DESCRIPTION
## Summary

- Adds an **↑ JSON** button to the TipTap editor toolbar
- Admin can upload a `.json` file; it is validated server-side (valid JSON + TipTap `{ type: "doc", content: [...] }` structure) before loading into the editor
- If the editor already has content, a `window.confirm` dialog warns before replacing
- Unknown node types are normalised to paragraphs with a warning message shown below the editor
- Draft / Save / Publish / Discard flows are entirely unchanged

## Files changed

| File | Change |
|------|--------|
| `src/app/api/blog/import-json/route.ts` | New `POST` route — auth guard, 5 MB limit, tmp file write/cleanup, JSON + TipTap validation, node normalization |
| `src/services/blog/importJson.ts` | New client service wrapping the endpoint |
| `src/components/BlogEditor/index.tsx` | Hidden file input + "↑ JSON" toolbar button + `handleJsonImport` handler with `editor.isDestroyed` guard |

## Test plan

- [ ] Go to `/admin/posts/new` → "↑ JSON" button visible in toolbar
- [ ] Upload a file with invalid JSON content → error: "Invalid JSON: file could not be parsed"
- [ ] Upload `{"foo":"bar"}` → error: "Not a valid TipTap document..."
- [ ] Upload a valid TipTap doc → content loads into editor
- [ ] Add text, then upload a second JSON → `window.confirm` appears; cancel → content unchanged
- [ ] Save / Publish / Discard all still work after an import