### PR TITLE
feat: per-project case-study pages from GitHub READMEs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,11 @@ Required in `.env`:
 - `NEXT_PUBLIC_CLOUDINARY_RES_LINK` — Cloudinary base URL for assets
 - `NEXT_PUBLIC_GA_ID` — Google Analytics measurement ID
 
+Optional:
+- `GITHUB_USERNAME` — used by `getGitHubStats` (home page repo/commit/LOC stats)
+- `GITHUB_TOKEN` — raises the GitHub API rate limit for `getGitHubStats` and for the
+  per-project README fetch (`src/lib/github.ts`). Works without it for a few projects.
+
 ## Architecture
 
 This is a **Next.js 15 App Router** portfolio site (TypeScript). All pages are server components that fetch data directly from MongoDB at request time (`force-dynamic`, `revalidate = 0`).

--- a/modals/project.ts
+++ b/modals/project.ts
@@ -22,6 +22,9 @@ const projectSchema = new Schema(
     summary: {
       type: String,
     },
+    tagLine: {
+      type: String,
+    },
     link: {
       type: String,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "highlight.js": "^11.11.1",
         "isomorphic-dompurify": "^3.15.0",
         "lowlight": "^3.3.0",
+        "marked": "^18.0.5",
         "moment": "^2.30.1",
         "mongoose": "^8.15.1",
         "next": "15.5.19",
@@ -6048,6 +6049,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "highlight.js": "^11.11.1",
     "isomorphic-dompurify": "^3.15.0",
     "lowlight": "^3.3.0",
+    "marked": "^18.0.5",
     "moment": "^2.30.1",
     "mongoose": "^8.15.1",
     "next": "15.5.19",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -18,6 +18,7 @@
 - Home: https://theharshdeepsingh.com/
 - Skills: https://theharshdeepsingh.com/skills
 - Projects: https://theharshdeepsingh.com/projects
+  - Projects with a substantial GitHub README have a dedicated case-study page at /projects/[slug]
 - Work Experience: https://theharshdeepsingh.com/experiences
 - Education: https://theharshdeepsingh.com/education
 - Resume: https://theharshdeepsingh.com/resume

--- a/src/app/projects/[slug]/opengraph-image.tsx
+++ b/src/app/projects/[slug]/opengraph-image.tsx
@@ -1,0 +1,66 @@
+import { getData } from "@/lib/getData";
+import { ImageResponse } from "next/og";
+
+export const runtime = "nodejs";
+export const revalidate = 3600;
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "Project case study by Harshdeep Singh";
+
+// Brand cyan + dark background — no theme access inside ImageResponse, so the
+// key tokens are inlined here.
+const ACCENT = "#38bdf8";
+const BG = "#0a0a0a";
+
+export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const project = await getData.getProjectBySlug(slug);
+
+  const name = project?.name ?? "Project";
+  const tech = (project?.technologyStack ?? []).slice(0, 6).join("  •  ");
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: BG,
+          padding: "80px",
+          backgroundImage: `radial-gradient(circle at 100% 0%, rgba(56,189,248,0.18), transparent 45%)`,
+        }}
+      >
+        <div style={{ display: "flex", color: ACCENT, fontSize: 30, letterSpacing: 2 }}>
+          {"> CASE STUDY"}
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
+          <div
+            style={{
+              display: "flex",
+              color: "#ffffff",
+              fontSize: 76,
+              fontWeight: 700,
+              lineHeight: 1.1,
+            }}
+          >
+            {name}
+          </div>
+          {tech && (
+            <div style={{ display: "flex", color: "#9ca3af", fontSize: 30 }}>{tech}</div>
+          )}
+        </div>
+
+        <div style={{ display: "flex", color: "#e5e7eb", fontSize: 32, fontWeight: 500 }}>
+          Harshdeep Singh
+          <span style={{ color: ACCENT, marginLeft: 12 }}>— Full Stack Developer</span>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,140 @@
+import Breadcrumbs from "@/components/Breadcrumbs";
+import ProjectCaseStudy from "@/components/ProjectCaseStudy";
+import { getData, type ProjectDetail } from "@/lib/getData";
+import { fetchReadmeHtml, README_MIN_CHARS } from "@/lib/github";
+import { safeJsonLd } from "@/lib/jsonLd";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+export const revalidate = 3600;
+
+const SITE_URL = "https://theharshdeepsingh.com";
+const SUMMARY_MIN_CHARS = 150;
+
+function stripHtml(value?: string): string {
+  return (value ?? "").replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function metaDescription(project: ProjectDetail): string {
+  const summary = stripHtml(project.summary);
+  if (summary) return summary.length > 160 ? `${summary.slice(0, 157)}…` : summary;
+  const tech = project.technologyStack?.join(", ");
+  return tech ? `A ${tech} project by Harshdeep Singh.` : "A project by Harshdeep Singh.";
+}
+
+/**
+ * Resolve a project AND verify it qualifies for a case-study page (substantial
+ * README + original intro). Returns null when missing or gated. Shared by
+ * generateMetadata and the page so the noindex/404 decision is consistent.
+ * The README fetch is cached (revalidate 3600), so calling this twice per
+ * request costs one GitHub round-trip.
+ */
+async function loadEligibleProject(
+  slug: string,
+): Promise<{ project: ProjectDetail; html: string } | null> {
+  const project = await getData.getProjectBySlug(slug);
+  if (!project) return null;
+  if ((project.summary?.length ?? 0) < SUMMARY_MIN_CHARS) return null;
+  const readme = await fetchReadmeHtml(project.link);
+  if (!readme || readme.textLength < README_MIN_CHARS) return null;
+  return { project, html: readme.html };
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const eligible = await loadEligibleProject(slug);
+  // Missing or gated → soft-404 page; mark noindex so it can never be indexed
+  // (notFound() renders a 200 in this app due to global middleware).
+  if (!eligible) {
+    return { title: "Project not found", robots: { index: false, follow: false } };
+  }
+  const { project } = eligible;
+
+  const url = `${SITE_URL}/projects/${slug}`;
+  const title = `${project.name} | Harshdeep Singh`;
+  const description = metaDescription(project);
+
+  return {
+    title,
+    description,
+    // Canonical for hygiene only — does not de-duplicate against github.com.
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "Harshdeep Singh",
+      locale: "en_US",
+      type: "article",
+      ...(project.startDate && { publishedTime: project.startDate }),
+      ...(project.updatedAt && { modifiedTime: project.updatedAt }),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+const ProjectDetailPage = async ({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) => {
+  const { slug } = await params;
+  const eligible = await loadEligibleProject(slug);
+  if (!eligible) notFound();
+  const { project, html } = eligible;
+
+  const url = `${SITE_URL}/projects/${slug}`;
+  const description = metaDescription(project);
+
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: project.name,
+    description,
+    ...(project.startDate && { datePublished: project.startDate }),
+    ...(project.updatedAt && { dateModified: project.updatedAt }),
+    inLanguage: "en-US",
+    author: { "@id": `${SITE_URL}/#person` },
+    publisher: { "@id": `${SITE_URL}/#person` },
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    ...(project.technologyStack?.length && {
+      keywords: project.technologyStack.join(", "),
+    }),
+    about: {
+      "@type": "SoftwareSourceCode",
+      name: project.name,
+      ...(project.link && { codeRepository: project.link }),
+      ...(project.technologyStack?.length && {
+        programmingLanguage: project.technologyStack,
+      }),
+      ...(project.website && { url: project.website }),
+    },
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLd(articleJsonLd) }}
+      />
+      <Breadcrumbs
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Projects", href: "/projects" },
+          { label: project.name ?? "Project", href: `/projects/${slug}` },
+        ]}
+      />
+      <ProjectCaseStudy project={project} safeHtml={html} />
+    </>
+  );
+};
+
+export default ProjectDetailPage;

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -40,7 +40,19 @@ export const metadata: Metadata = {
 const siteUrl = "https://theharshdeepsingh.com";
 
 const Projects = async () => {
-  const projects = await getData.getProjects();
+  const [projects, caseStudyIndex] = await Promise.all([
+    getData.getProjects(),
+    getData.getProjectCaseStudyIndex(),
+  ]);
+
+  // Map project name → { slug, hasCaseStudy } so cards can link eligible ones.
+  const caseStudyMap: Record<string, { slug: string; hasCaseStudy: boolean }> =
+    Object.fromEntries(
+      caseStudyIndex.map((entry) => [
+        entry.name,
+        { slug: entry.slug, hasCaseStudy: entry.hasCaseStudy },
+      ]),
+    );
 
   const projectsItemListJsonLd = projects?.length
     ? {
@@ -87,7 +99,7 @@ const Projects = async () => {
           { label: "Projects", href: "/projects" },
         ]}
       />
-      <ProjectsComponent projects={projects} />
+      <ProjectsComponent projects={projects} caseStudyMap={caseStudyMap} />
     </>
   );
 };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -68,5 +68,27 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error("[sitemap] Failed to fetch blog posts:", err);
   }
 
-  return [...staticEntries, ...blogPostEntries];
+  let projectEntries: MetadataRoute.Sitemap = [];
+  try {
+    const caseStudies = await getData.getProjectCaseStudyIndex();
+    projectEntries = caseStudies
+      .filter((p) => p.hasCaseStudy)
+      .map((p) => {
+        // README can change without the DB doc being re-saved — use the freshest signal.
+        const stamps = [p.updatedAt, p.readmeLastModified]
+          .filter((d): d is string => Boolean(d))
+          .map((d) => new Date(d).getTime())
+          .filter((t) => !isNaN(t));
+        return {
+          url: `${siteUrl}/projects/${p.slug}`,
+          lastModified: stamps.length ? new Date(Math.max(...stamps)) : now,
+          changeFrequency: "monthly" as const,
+          priority: 0.8, // matches blog posts; these are primary SEO targets
+        };
+      });
+  } catch (err) {
+    console.error("[sitemap] Failed to fetch project case studies:", err);
+  }
+
+  return [...staticEntries, ...blogPostEntries, ...projectEntries];
 }

--- a/src/components/ProjectCaseStudy/index.tsx
+++ b/src/components/ProjectCaseStudy/index.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Container, PageHeader } from "@/app/_globalStyles";
+import { CardLink, CardLinksContainer } from "@/components/Card/styles";
+import { TechItem } from "@/components/ProjectsComponent/styles";
+import { faGithub } from "@fortawesome/free-brands-svg-icons";
+import { faCalendar, faGlobe } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTheme } from "@mui/material/styles";
+
+interface ProjectCaseStudyProps {
+  project: {
+    name?: string;
+    summary?: string;
+    technologyStack?: string[];
+    link?: string;
+    website?: string;
+    startDate?: string;
+    endDate?: string;
+    isPresent?: boolean;
+  };
+  safeHtml: string;
+}
+
+function formatMonthYear(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+function formatRange(start?: string, end?: string, isPresent?: boolean): string {
+  if (!start) return "";
+  const startLabel = formatMonthYear(start);
+  const endLabel = isPresent ? "Present" : end ? formatMonthYear(end) : "";
+  return endLabel ? `${startLabel} – ${endLabel}` : startLabel;
+}
+
+const ProjectCaseStudy = ({ project, safeHtml }: ProjectCaseStudyProps) => {
+  const theme = useTheme();
+  const dateRange = formatRange(project.startDate, project.endDate, project.isPresent);
+
+  return (
+    <Container>
+      <PageHeader component="h1" sx={{ textAlign: "left", fontSize: { xs: "2rem", md: "2.75rem" } }}>
+        {project.name}
+      </PageHeader>
+
+      {/* Meta row: dates + repo/live links */}
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: "1rem",
+          margin: "1.25rem 0 1.75rem",
+          fontSize: "0.875rem",
+          opacity: 0.85,
+        }}
+      >
+        {dateRange && (
+          <span>
+            <FontAwesomeIcon icon={faCalendar} style={{ marginRight: "6px" }} />
+            {dateRange}
+          </span>
+        )}
+        {(project.link || project.website) && (
+          <CardLinksContainer>
+            {project.link && (
+              <CardLink href={project.link} target="_blank" rel="noreferrer noopener" aria-label="GitHub repository">
+                <FontAwesomeIcon icon={faGithub} />
+              </CardLink>
+            )}
+            {project.website && (
+              <CardLink href={project.website} target="_blank" rel="noreferrer noopener" aria-label="Live website">
+                <FontAwesomeIcon icon={faGlobe} />
+              </CardLink>
+            )}
+          </CardLinksContainer>
+        )}
+      </div>
+
+      {/* Original framing intro (sits above the README) */}
+      {project.summary && (
+        <div
+          dangerouslySetInnerHTML={{ __html: project.summary }}
+          style={{
+            fontSize: "1.15rem",
+            lineHeight: 1.7,
+            color: theme.palette.text.secondary,
+            fontWeight: 300,
+            margin: "0 0 1.5rem",
+          }}
+        />
+      )}
+
+      {/* Tech stack chips */}
+      {project.technologyStack && project.technologyStack.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "0.75rem",
+            margin: "0 0 2.25rem",
+            paddingBottom: "1.5rem",
+            borderBottom: `1px solid ${theme.palette.divider}`,
+          }}
+        >
+          {project.technologyStack.map((tech) => (
+            <TechItem key={tech}>{tech}</TechItem>
+          ))}
+        </div>
+      )}
+
+      {/* README body (sanitized) — reuses the blog prose styling */}
+      {safeHtml && (
+        <div
+          className="blog-post-body"
+          dangerouslySetInnerHTML={{ __html: safeHtml }}
+          style={{ lineHeight: 1.85, fontSize: "1.05rem" }}
+        />
+      )}
+    </Container>
+  );
+};
+
+export default ProjectCaseStudy;

--- a/src/components/ProjectCaseStudy/index.tsx
+++ b/src/components/ProjectCaseStudy/index.tsx
@@ -12,6 +12,7 @@ interface ProjectCaseStudyProps {
   project: {
     name?: string;
     summary?: string;
+    tagLine?: string;
     technologyStack?: string[];
     link?: string;
     website?: string;
@@ -42,6 +43,21 @@ const ProjectCaseStudy = ({ project, safeHtml }: ProjectCaseStudyProps) => {
       <PageHeader component="h1" sx={{ textAlign: "left", fontSize: { xs: "2rem", md: "2.75rem" } }}>
         {project.name}
       </PageHeader>
+
+      {project.tagLine && (
+        <p
+          style={{
+            margin: "0.5rem 0 0",
+            fontSize: "1.25rem",
+            lineHeight: 1.5,
+            fontStyle: "italic",
+            fontWeight: 300,
+            color: theme.palette.custom.tertiaryText,
+          }}
+        >
+          {project.tagLine}
+        </p>
+      )}
 
       {/* Meta row: dates + repo/live links */}
       <div

--- a/src/components/ProjectsComponent/ProjectCard.tsx
+++ b/src/components/ProjectsComponent/ProjectCard.tsx
@@ -4,7 +4,7 @@ import { faGlobe } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 // import ColorThief from "colorthief/dist/color-thief.mjs";
 import { CardLink, CardLinksContainer } from "../Card/styles";
-import { ProjectItem, ProjectLogo, TechItem } from "./styles";
+import { CaseStudyLink, ProjectItem, ProjectLogo, TechItem } from "./styles";
 
 const LOGO_MAP: Record<string, string> = {
   "Unconventional Music Player": "/assets/logos/unconventional-player.svg",
@@ -15,7 +15,15 @@ const LOGO_MAP: Record<string, string> = {
   "StockFlow AI": "/assets/logos/stockflowAI.png",
 };
 
-const ProjectCard = ({ project, delay }: { project: any; delay?: number }) => {
+const ProjectCard = ({
+  project,
+  delay,
+  caseStudy,
+}: {
+  project: any;
+  delay?: number;
+  caseStudy?: { slug: string; hasCaseStudy: boolean };
+}) => {
 
   return (
     <ProjectItem key={project._id} delay={delay}>
@@ -40,6 +48,12 @@ const ProjectCard = ({ project, delay }: { project: any; delay?: number }) => {
         {project.tagLine && <div className="tag-line-container">{project.tagLine}</div>}
 
         {project.summary && <div className="summary-container" dangerouslySetInnerHTML={{ __html: project.summary }} />}
+
+        {caseStudy?.hasCaseStudy && (
+          <CaseStudyLink href={`/projects/${caseStudy.slug}`}>
+            View case study <span aria-hidden="true">→</span>
+          </CaseStudyLink>
+        )}
       </div>
 
       {project?.technologyStack && (

--- a/src/components/ProjectsComponent/index.tsx
+++ b/src/components/ProjectsComponent/index.tsx
@@ -6,7 +6,15 @@ import { Container, PageHeader } from "../../app/_globalStyles";
 import ProjectCard from "./ProjectCard";
 import { ProjectsRow } from "./styles";
 
-const ProjectsComponent = ({ projects }: { projects: any }) => {
+type CaseStudyMap = Record<string, { slug: string; hasCaseStudy: boolean }>;
+
+const ProjectsComponent = ({
+  projects,
+  caseStudyMap = {},
+}: {
+  projects: any;
+  caseStudyMap?: CaseStudyMap;
+}) => {
   return (
     <>
       <Container>
@@ -18,7 +26,11 @@ const ProjectsComponent = ({ projects }: { projects: any }) => {
         <ProjectsRow spacing={3} sx={{alignItems: "stretch"}} >
           {projects?.map((project: any, index: number) => (
             <Grid2 key={project._id} size={{ xs: 12, sm: 6, md: 4 }} sx={{alignItems: "stretch", display: "flex"}} >
-              <ProjectCard project={project} delay={0.15 + index * 0.07} />
+              <ProjectCard
+                project={project}
+                delay={0.15 + index * 0.07}
+                caseStudy={caseStudyMap[project.name]}
+              />
             </Grid2>
           ))}
         </ProjectsRow>

--- a/src/components/ProjectsComponent/styles.tsx
+++ b/src/components/ProjectsComponent/styles.tsx
@@ -1,6 +1,7 @@
 import Image from "@/elements/Image";
 import { fadeIn } from "@/theme/animations";
 import { styled } from "@mui/material/styles";
+import Link from "next/link";
 import Card from "../Card";
 import { CardTag } from "../Card/styles";
 import { Row } from "@/app/_globalStyles";
@@ -55,6 +56,22 @@ export const ProjectItem = styled(Card, {
     color: theme.palette.text.secondary,
     fontWeight: 300,
     margin: "1.5em 0 1.8em 0",
+  },
+}));
+
+export const CaseStudyLink = styled(Link)(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "0.35em",
+  marginTop: "0.25em",
+  fontSize: "0.9em",
+  fontWeight: 500,
+  color: theme.palette.primary.main,
+  textDecoration: "none",
+  transition: "gap 0.2s ease, opacity 0.2s ease",
+  "&:hover": {
+    opacity: 0.8,
+    gap: "0.6em",
   },
 }));
 

--- a/src/lib/getData.ts
+++ b/src/lib/getData.ts
@@ -26,6 +26,7 @@ export interface ProjectDetail {
   _id?: string;
   name?: string;
   summary?: string;
+  tagLine?: string;
   technologyStack?: string[];
   link?: string;
   website?: string;

--- a/src/lib/getData.ts
+++ b/src/lib/getData.ts
@@ -7,8 +7,82 @@ import user from "../../modals/user";
 import workExperience from "../../modals/workExperience";
 import { connectToDB, connectToBlogsDB } from "./mongoose";
 import type { BlogPost, BlogPostForSitemap, BlogPostPreview } from "@/types/blog";
+import { unstable_cache } from "next/cache";
+import slugify from "slugify";
+import { fetchReadmeHtml, parseRepo, README_MIN_CHARS } from "./github";
 
 const userEmail = process.env.UESR_EMAIL;
+
+// Minimum raw `summary` length for a project to earn a case-study page.
+// The summary is the original intro that sits above the (GitHub-duplicated)
+// README — this is the original-text-ratio gate, not just README bulk.
+const SUMMARY_MIN_CHARS = 150;
+
+/** Derive a project's URL slug from its name — same slugify config the blog uses. */
+export const slugifyProjectName = (name?: string): string =>
+  name ? slugify(name, { lower: true, strict: true }) : "";
+
+export interface ProjectDetail {
+  _id?: string;
+  name?: string;
+  summary?: string;
+  technologyStack?: string[];
+  link?: string;
+  website?: string;
+  startDate?: string;
+  endDate?: string;
+  isPresent?: boolean;
+  updatedAt?: string;
+  slug: string;
+}
+
+export interface ProjectCaseStudyEntry {
+  slug: string;
+  name: string;
+  updatedAt: string | null;
+  readmeLastModified: string | null;
+  hasCaseStudy: boolean;
+}
+
+// Build the case-study eligibility index: for every project with a parseable
+// GitHub link, fetch its README (in parallel) and decide whether it qualifies
+// for a dedicated page. Wrapped in unstable_cache so the GitHub calls are cached
+// for an hour regardless of the calling route's `dynamic` setting (sitemap.ts is
+// force-dynamic and would otherwise re-fetch every README on each crawl).
+const buildProjectCaseStudyIndex = unstable_cache(
+  async (): Promise<ProjectCaseStudyEntry[]> => {
+    await connectToDB();
+    const docs = await project
+      .find({ user: userEmail }, undefined, { sort: { startDate: -1 } })
+      .lean();
+    const list = JSON.parse(JSON.stringify(docs)) as Array<{
+      name?: string;
+      summary?: string;
+      link?: string;
+      updatedAt?: string;
+    }>;
+
+    const entries = await Promise.all(
+      list.map(async (p) => {
+        if (!parseRepo(p.link)) return null;
+        const summaryLen = typeof p.summary === "string" ? p.summary.length : 0;
+        const readme = await fetchReadmeHtml(p.link).catch(() => null);
+        const textLength = readme?.textLength ?? 0;
+        return {
+          slug: slugifyProjectName(p.name),
+          name: p.name ?? "",
+          updatedAt: p.updatedAt ?? null,
+          readmeLastModified: readme?.readmeLastModified ?? null,
+          hasCaseStudy: textLength >= README_MIN_CHARS && summaryLen >= SUMMARY_MIN_CHARS,
+        } satisfies ProjectCaseStudyEntry;
+      }),
+    );
+
+    return entries.filter((e): e is ProjectCaseStudyEntry => e !== null);
+  },
+  ["project-case-study-index-v1"],
+  { revalidate: 3600 },
+);
 
 const attachAuthorNames = async (
   conn: Awaited<ReturnType<typeof connectToBlogsDB>>,
@@ -88,6 +162,26 @@ export const getData = {
     await connectToDB();
     const data = await project.find({ user: userEmail }, undefined, { sort: { startDate: -1 } }).lean();
     return JSON.parse(JSON.stringify(data));
+  },
+  // Resolve a project by its derived slug. Slugs aren't stored, so we slugify
+  // each project's name and match — O(projects), fine at this scale.
+  getProjectBySlug: async (slug: string): Promise<ProjectDetail | null> => {
+    await connectToDB();
+    const data = await project
+      .find({ user: userEmail }, undefined, { sort: { startDate: -1 } })
+      .lean();
+    const list = JSON.parse(JSON.stringify(data)) as ProjectDetail[];
+    const match = list.find((p) => p.name && slugifyProjectName(p.name) === slug);
+    return match ? { ...match, slug } : null;
+  },
+  // Case-study eligibility index, shared by the listing and the sitemap.
+  // Degrades gracefully (empty array) if GitHub is unreachable.
+  getProjectCaseStudyIndex: async (): Promise<ProjectCaseStudyEntry[]> => {
+    try {
+      return await buildProjectCaseStudyIndex();
+    } catch {
+      return [];
+    }
   },
   getWorkExperiences: async () => {
     // Disable caching so experience updates are reflected on first refresh.

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,3 +1,7 @@
+import "server-only";
+import { marked } from "marked";
+import { sanitizeHtml } from "./sanitize";
+
 interface GitHubStats {
   repos: number;
   commits: number;
@@ -52,5 +56,166 @@ export async function getGitHubStats(): Promise<GitHubStats> {
     return { repos, commits, linesOfCode };
   } catch {
     return { repos: 0, commits: 0, linesOfCode: 0 };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// README fetch + render — powers the per-project case-study pages.
+// Fetches a repo's README via the GitHub API (cached hourly), converts
+// markdown → HTML, demotes README headings so the page keeps a single H1,
+// rewrites relative links/images to absolute GitHub URLs, and sanitizes
+// the result (XSS + code highlighting) via the shared sanitizer.
+// ---------------------------------------------------------------------------
+
+// Minimum visible README text length for a project to earn a case-study page.
+export const README_MIN_CHARS = 300;
+
+export interface ReadmeResult {
+  html: string;
+  textLength: number;
+  readmeLastModified: string | null;
+}
+
+/**
+ * Extract `{ owner, repo }` from a github.com URL.
+ * Tolerates trailing slashes, `.git`, and extra path segments.
+ * Returns null for non-GitHub or unparseable links.
+ */
+export function parseRepo(link?: string | null): { owner: string; repo: string } | null {
+  if (!link || typeof link !== "string") return null;
+  try {
+    const url = new URL(link.trim());
+    const host = url.hostname.toLowerCase();
+    if (host !== "github.com" && host !== "www.github.com") return null;
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length < 2) return null;
+    const owner = parts[0];
+    const repo = parts[1].replace(/\.git$/i, "");
+    if (!owner || !repo) return null;
+    return { owner, repo };
+  } catch {
+    return null;
+  }
+}
+
+function readmeHeaders(): HeadersInit {
+  const token = process.env.GITHUB_TOKEN;
+  return {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+/** Demote every README heading one level (h1→h2 … h5→h6, h6 stays) so the page
+ *  has a single H1 (its own title) and README headings don't compete with it. */
+function demoteHeadings(html: string): string {
+  return html.replace(
+    /<(\/?)(h)([1-5])([^>]*)>/gi,
+    (_m, slash: string, _h: string, level: string, attrs: string) =>
+      `<${slash}h${Number(level) + 1}${attrs}>`,
+  );
+}
+
+function isAbsoluteUrl(url: string): boolean {
+  return (
+    /^[a-z][a-z0-9+.-]*:/i.test(url) || // protocol (https:, mailto:, data:, …)
+    url.startsWith("//") ||
+    url.startsWith("#")
+  );
+}
+
+function resolveAgainst(base: string, rel: string): string {
+  try {
+    return new URL(rel, base).href;
+  } catch {
+    return rel;
+  }
+}
+
+/** Derive raw/blob base URLs (with the real default branch) from the readme
+ *  response's download_url, e.g.
+ *  https://raw.githubusercontent.com/owner/repo/main/docs/README.md */
+function deriveBases(
+  downloadUrl: string | undefined,
+  repo: { owner: string; repo: string },
+): { rawBase: string; blobBase: string } {
+  let branch = "HEAD";
+  let dir = "";
+  if (downloadUrl) {
+    try {
+      const parts = new URL(downloadUrl).pathname.split("/").filter(Boolean);
+      // [owner, repo, branch, ...path, filename]
+      branch = parts[2] || "HEAD";
+      const dirParts = parts.slice(3, -1);
+      dir = dirParts.length ? `${dirParts.join("/")}/` : "";
+    } catch {
+      /* fall back to HEAD */
+    }
+  }
+  return {
+    rawBase: `https://raw.githubusercontent.com/${repo.owner}/${repo.repo}/${branch}/${dir}`,
+    blobBase: `https://github.com/${repo.owner}/${repo.repo}/blob/${branch}/${dir}`,
+  };
+}
+
+/** Rewrite relative <img src> → raw.githubusercontent and relative <a href> →
+ *  github.com/blob so README assets/links resolve off-GitHub. */
+function rewriteRelativeUrls(html: string, bases: { rawBase: string; blobBase: string }): string {
+  html = html.replace(
+    /(<img\b[^>]*?\bsrc=)(["'])(.*?)\2/gi,
+    (m, pre: string, q: string, url: string) =>
+      isAbsoluteUrl(url) ? m : `${pre}${q}${resolveAgainst(bases.rawBase, url)}${q}`,
+  );
+  html = html.replace(
+    /(<a\b[^>]*?\bhref=)(["'])(.*?)\2/gi,
+    (m, pre: string, q: string, url: string) =>
+      isAbsoluteUrl(url) ? m : `${pre}${q}${resolveAgainst(bases.blobBase, url)}${q}`,
+  );
+  return html;
+}
+
+/**
+ * Fetch + render a repo's README as sanitized HTML. Returns null on any failure
+ * (non-GitHub link, 404, network error) so callers degrade gracefully.
+ */
+export async function fetchReadmeHtml(link?: string | null): Promise<ReadmeResult | null> {
+  const repo = parseRepo(link);
+  if (!repo) return null;
+
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${repo.owner}/${repo.repo}/readme`,
+      { headers: readmeHeaders(), next: { revalidate: 3600 } },
+    );
+    if (!res.ok) return null;
+
+    const readmeLastModified = res.headers.get("last-modified");
+    const json = (await res.json()) as {
+      content?: string;
+      encoding?: string;
+      download_url?: string;
+    };
+    if (!json.content) return null;
+
+    const markdown = Buffer.from(
+      json.content,
+      (json.encoding as BufferEncoding) || "base64",
+    ).toString("utf-8");
+    if (!markdown.trim()) return null;
+
+    let html = await marked.parse(markdown, { gfm: true });
+    html = demoteHeadings(html);
+    html = rewriteRelativeUrls(html, deriveBases(json.download_url, repo));
+
+    const clean = await sanitizeHtml(html);
+    const textLength = clean
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim().length;
+
+    return { html: clean, textLength, readmeLastModified };
+  } catch {
+    return null;
   }
 }

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -183,6 +183,7 @@ export const createAppTheme = (mode: PaletteMode = "light") => {
           /* Images */
           .blog-post-body img {
             max-width: 100%;
+            height: auto;
             border-radius: 8px;
             margin: 1.5em 0;
             display: block;


### PR DESCRIPTION
## What & why

An SEO expert recommended giving each project its own URL so it can rank for its own terms and earn its own links. This adds `/projects/[slug]` case-study pages built from each project's **GitHub README** (fetched + cached hourly) with the existing `summary` as an original framing intro — substantial content with **no manual writing and no new editable fields** (no career-canvas change needed).

## How

- **`src/lib/github.ts`** — `fetchReadmeHtml()`: GitHub API readme fetch, markdown→HTML (`marked`), **README headings demoted** so the page keeps a single H1, relative links/images rewritten to absolute GitHub URLs, sanitized via the existing `sanitizeHtml`. (Appends to the existing `getGitHubStats` util — kept intact.)
- **`src/lib/getData.ts`** — `slugifyProjectName`, `getProjectBySlug`, and `getProjectCaseStudyIndex` wrapped in `unstable_cache` so the **force-dynamic** sitemap doesn't re-fetch every README per crawl.
- **`src/app/projects/[slug]/page.tsx`** — `TechArticle` JSON-LD (mirrors the blog's article schema; avoids `SoftwareApplication` Search Console warnings), `article` OpenGraph, canonical. **Gated**: page only builds when README ≥ 300 chars **and** summary ≥ 150 chars (original-text-ratio guard against thin/duplicate content).
- **`src/app/projects/[slug]/opengraph-image.tsx`** — per-project OG image (name + tech stack), no new DB field.
- **Listing** links eligible case studies; **sitemap** includes them with freshest of DB `updatedAt` / README `Last-Modified`.
- Docs: `GITHUB_TOKEN`/`GITHUB_USERNAME` env note, `llms.txt`; `.blog-post-body img { height:auto }` for CLS.

## SEO notes / known limitations

- README content partially duplicates github.com — self-canonical does **not** de-dupe cross-domain. Mitigated by the `summary` intro + headers + tech chips + JSON-LD (original-text ratio). Expectation: indexable, good-UX pages; ranking uplift modest.
- **Soft-404**: `notFound()` renders a 200 in this app (pre-existing, global middleware — the blog behaves identically). Neutralized for SEO by emitting **`noindex`** on missing/gated pages, plus they're absent from the sitemap and unlinked.
- Slugs are derived from the project name; renaming a project changes its URL (acceptable now; stored slug/redirect map is the later escape hatch).

## Verification

Built (`npm run build` green) and exercised against live data on `npm start`:
- 4 projects qualify — consistent across `/projects` "View case study" links and `/sitemap.xml`.
- Detail page: 200, **single `<h1>`**, README headings demoted to h2/h3, `TechArticle` JSON-LD, canonical, README rendered.
- Per-project `opengraph-image` returns a 200 PNG.
- Missing/gated slug → not-found page carrying `noindex`; absent from sitemap.
- Sitemap served from cache on repeat (`unstable_cache` holds under force-dynamic).